### PR TITLE
fix: no need to check if directory exists

### DIFF
--- a/Vertminer/Main.vb
+++ b/Vertminer/Main.vb
@@ -39,9 +39,9 @@ Public Class Main
 
             _logger = New FileLogger(syslog)
 
-            If System.IO.Directory.Exists(settingsfolder) = False Then
-                System.IO.Directory.CreateDirectory(settingsfolder)
-            End If
+            
+            System.IO.Directory.CreateDirectory(settingsfolder)
+           
             If System.IO.File.Exists(settingsfolder & "\Settings.ini") = True Then
                 Invoke(New MethodInvoker(AddressOf Update_Settings))
             Else


### PR DESCRIPTION
The System.IO.Directory.CreateDirectory call will only add the directory if it does not already exist.