### PR TITLE
 Add Vertcoin address validation

### DIFF
--- a/OneClickMiner.Tests/OneClickMiner.Tests.vbproj
+++ b/OneClickMiner.Tests/OneClickMiner.Tests.vbproj
@@ -92,6 +92,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="VertcoinAddressUtilityTests.vb" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="My Project\Resources.resx">

--- a/OneClickMiner.Tests/VertcoinAddressUtilityTests.vb
+++ b/OneClickMiner.Tests/VertcoinAddressUtilityTests.vb
@@ -1,0 +1,21 @@
+﻿Imports NUnit.Framework
+Imports VertcoinOneClickMiner.Core
+
+<TestFixture>
+Public Class VertcoinAddressUtilityTests
+    <Test>
+    <TestCase("VnkLyFgSnZShC9d52Xf9YTRPcUXyoypT4u")>
+    <TestCase("VfukW89WKT9h3YjHZdSAAuGNVGELY31wyj")>
+    <TestCase("VoCJWKjFc8PFTMhDarKwCYGdggpgHn6L43")>
+    Public Sub IsWalletAddressValid_WhenCalledWithValidWalletAddress_ShouldReturnTrue(walletAddress As String)
+        Assert.IsTrue(VertcoinAddressUtility.IsWalletAddressValid(walletAddress))
+    End Sub
+
+    <Test>
+    <TestCase("x")>
+    <TestCase("16rCmCmbuWDhPjWTrpQGaU3EPdZF7MTdUk")> 'Bitcoin address
+    <TestCase("")>
+    Public Sub IsWalletAddressValid_WhenCalledWithInvalidWalletAddress_ShouldReturnFalse(walletAddress As String)
+        Assert.IsFalse(VertcoinAddressUtility.IsWalletAddressValid(walletAddress))
+    End Sub
+End Class

--- a/Vertminer/Core/Base58.vb
+++ b/Vertminer/Core/Base58.vb
@@ -1,0 +1,34 @@
+﻿'https://github.com/casascius/Bitcoin-Address-Utility
+Namespace Core
+    Public Class Base58
+
+        ''' <summary>
+        ''' Converts a base-58 string to a byte array, returning Nothing if it wasn't valid.
+        ''' </summary>
+        Public Shared Function ToByteArray(ByVal base58 As String) As Byte()
+            Dim bi2 = New Org.BouncyCastle.Math.BigInteger("0")
+            Dim b58 As String = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+            For Each c As Char In base58
+                If (b58.IndexOf(c) <> -1) Then
+                    bi2 = bi2.Multiply(New Org.BouncyCastle.Math.BigInteger("58"))
+                    bi2 = bi2.Add(New Org.BouncyCastle.Math.BigInteger(b58.IndexOf(c).ToString))
+                Else
+                    Return Nothing
+                End If
+
+            Next
+            Dim bb() As Byte = bi2.ToByteArrayUnsigned
+            ' interpret leading '1's as leading zero bytes
+            For Each c As Char In base58
+                If (c <> Microsoft.VisualBasic.ChrW(49)) Then
+                    Exit For
+                End If
+
+                Dim bbb() As Byte = New Byte(bb.Length) {}
+                Array.Copy(bb, 0, bbb, 1, bb.Length)
+                bb = bbb
+            Next
+            Return bb
+        End Function
+    End Class
+End Namespace

--- a/Vertminer/Core/VertcoinAddressUtility.vb
+++ b/Vertminer/Core/VertcoinAddressUtility.vb
@@ -1,0 +1,58 @@
+﻿'https://github.com/casascius/Bitcoin-Address-Utility
+Imports Org.BouncyCastle.Crypto.Digests
+
+Namespace Core
+    Public Class VertcoinAddressUtility
+        ''' <summary>
+        ''' Converts a base-58 string to a byte array, checking the checksum, and
+        ''' returning Nothing if it wasn't valid.  Appending "?" to the end of the string skips
+        ''' the checksum calculation, but still strips the four checksum bytes from the
+        ''' result.
+        ''' </summary>
+        Public Shared Function Base58CheckToByteArray(ByVal base58_string As String) As Byte()
+            Dim IgnoreChecksum As Boolean = False
+            If base58_string.EndsWith("?") Then
+                IgnoreChecksum = True
+                base58_string = base58_string.Substring(0, (base58_string.Length - 1))
+            End If
+
+            Dim bb() As Byte = Base58.ToByteArray(base58_string)
+            If ((bb Is Nothing) OrElse (bb.Length < 4)) Then
+                Return Nothing
+            End If
+
+            If Not IgnoreChecksum Then
+                Dim bcsha256a = New Sha256Digest
+                bcsha256a.BlockUpdate(bb, 0, (bb.Length - 4))
+                Dim checksum() As Byte = New Byte((32) - 1) {}
+                bcsha256a.DoFinal(checksum, 0)
+                bcsha256a.BlockUpdate(checksum, 0, 32)
+                bcsha256a.DoFinal(checksum, 0)
+                Dim i As Integer = 0
+                Do While (i < 4)
+                    If (checksum(i) <> bb(((bb.Length - 4) + i))) Then
+                        Return Nothing
+                    End If
+
+                    i = (i + 1)
+                Loop
+
+            End If
+
+            Dim rv() As Byte = New Byte(((bb.Length - 4)) - 1) {}
+            Array.Copy(bb, 0, rv, 0, (bb.Length - 4))
+            Return rv
+        End Function
+
+        Public Shared Function IsWalletAddressValid(walletAddress As String) As Boolean
+            Dim walletBytes = Base58CheckToByteArray(walletAddress)
+            If walletBytes Is Nothing Then
+                Return False
+            End If
+            Dim versionByte = walletBytes(0)
+            Const P2PKH_VERBYTE = &H47
+            Const P2SH_VERBYTE = &H5
+            Return (versionByte = P2PKH_VERBYTE) Or (versionByte = P2SH_VERBYTE)
+        End Function
+    End Class
+End Namespace

--- a/Vertminer/P2Pool.Designer.vb
+++ b/Vertminer/P2Pool.Designer.vb
@@ -23,7 +23,7 @@ Partial Class P2Pool
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(P2Pool))
-        Me.Button1 = New System.Windows.Forms.Button()
+        Me.AddSelectedPoolsButton = New System.Windows.Forms.Button()
         Me.Wallet_Address = New System.Windows.Forms.TextBox()
         Me.Label3 = New System.Windows.Forms.Label()
         Me.Label4 = New System.Windows.Forms.Label()
@@ -57,18 +57,18 @@ Partial Class P2Pool
         Me.Panel2.SuspendLayout()
         Me.SuspendLayout()
         '
-        'Button1
+        'AddSelectedPoolsButton
         '
-        Me.Button1.BackColor = System.Drawing.Color.DarkGreen
-        Me.Button1.FlatStyle = System.Windows.Forms.FlatStyle.Popup
-        Me.Button1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.Button1.ForeColor = System.Drawing.SystemColors.Control
-        Me.Button1.Location = New System.Drawing.Point(637, 206)
-        Me.Button1.Name = "Button1"
-        Me.Button1.Size = New System.Drawing.Size(140, 26)
-        Me.Button1.TabIndex = 6
-        Me.Button1.Text = "Add Selected Pool(s)"
-        Me.Button1.UseVisualStyleBackColor = False
+        Me.AddSelectedPoolsButton.BackColor = System.Drawing.Color.DarkGreen
+        Me.AddSelectedPoolsButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup
+        Me.AddSelectedPoolsButton.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.AddSelectedPoolsButton.ForeColor = System.Drawing.SystemColors.Control
+        Me.AddSelectedPoolsButton.Location = New System.Drawing.Point(637, 206)
+        Me.AddSelectedPoolsButton.Name = "AddSelectedPoolsButton"
+        Me.AddSelectedPoolsButton.Size = New System.Drawing.Size(140, 26)
+        Me.AddSelectedPoolsButton.TabIndex = 6
+        Me.AddSelectedPoolsButton.Text = "Add Selected Pool(s)"
+        Me.AddSelectedPoolsButton.UseVisualStyleBackColor = False
         '
         'Wallet_Address
         '
@@ -283,7 +283,7 @@ Partial Class P2Pool
         '
         Me.Panel2.BackColor = System.Drawing.Color.DarkSlateGray
         Me.Panel2.Controls.Add(Me.TabControl1)
-        Me.Panel2.Controls.Add(Me.Button1)
+        Me.Panel2.Controls.Add(Me.AddSelectedPoolsButton)
         Me.Panel2.Controls.Add(Me.Label5)
         Me.Panel2.Controls.Add(Me.Button2)
         Me.Panel2.Controls.Add(Me.Wallet_Address)
@@ -334,7 +334,7 @@ Partial Class P2Pool
         Me.ResumeLayout(False)
 
     End Sub
-    Friend WithEvents Button1 As System.Windows.Forms.Button
+    Friend WithEvents AddSelectedPoolsButton As System.Windows.Forms.Button
     Friend WithEvents Wallet_Address As System.Windows.Forms.TextBox
     Friend WithEvents Label3 As System.Windows.Forms.Label
     Friend WithEvents Label4 As System.Windows.Forms.Label

--- a/Vertminer/P2Pool.vb
+++ b/Vertminer/P2Pool.vb
@@ -382,7 +382,7 @@ Public Class P2Pool
         Next
         checkcount = checkcount + checkcount2
         Dim pool_list = String.Join(",", pools.ToArray())
-        If Not Wallet_Address.Text = "" And checkcount > 0 Then
+        If VertcoinAddressUtility.IsWalletAddressValid(Wallet_Address.Text) And checkcount > 0 Then
             For Each row As DataGridViewRow In DataGridView1.Rows
                 Dim chk As DataGridViewCheckBoxCell = row.Cells(DataGridView1.Columns(0).Name)
                 If chk.Value IsNot Nothing AndAlso chk.Value = True Then
@@ -412,7 +412,7 @@ Public Class P2Pool
         ElseIf checkcount = 0 Then
             MsgBox("Please select a pool to add.")
         Else
-            MsgBox("Please enter a Wallet Address before adding pools.")
+            MsgBox("Please enter a Valid Wallet Address before adding pools.")
         End If
 
     End Sub

--- a/Vertminer/P2Pool.vb
+++ b/Vertminer/P2Pool.vb
@@ -364,7 +364,7 @@ Public Class P2Pool
 
     End Function
 
-    Private Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click
+    Private Sub AddSelectedPoolsButton_Click(sender As Object, e As EventArgs) Handles AddSelectedPoolsButton.Click
 
         Dim checkcount = 0
         Dim checkcount2 = 0
@@ -483,7 +483,7 @@ Public Class P2Pool
     Public Sub Style()
 
         Panel1.BackColor = Color.FromArgb(27, 92, 46)
-        Button1.BackColor = Color.FromArgb(27, 92, 46)
+        AddSelectedPoolsButton.BackColor = Color.FromArgb(27, 92, 46)
         Button2.BackColor = Color.FromArgb(27, 92, 46)
         Panel2.BackColor = Color.FromArgb(41, 54, 61)
         DataGridView1.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill

--- a/Vertminer/Vertcoin 'One-Click' Miner.vbproj
+++ b/Vertminer/Vertcoin 'One-Click' Miner.vbproj
@@ -67,6 +67,10 @@
     <ApplicationManifest>My Project\app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <HintPath>..\packages\BouncyCastle.Crypto.dll.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -116,6 +120,7 @@
     <Compile Include="AddPool.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Core\Base58.vb" />
     <Compile Include="Core\FileLogger.vb" />
     <Compile Include="Core\SystemWrapper.vb" />
     <Compile Include="Main.vb">
@@ -160,6 +165,7 @@
     </Compile>
     <Compile Include="Settings_Classes.vb" />
     <Compile Include="variables.vb" />
+    <Compile Include="Core\VertcoinAddressUtility.vb" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="about.resx">

--- a/Vertminer/packages.config
+++ b/Vertminer/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle.Crypto.dll" version="1.8.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="Open.NAT" version="2.1.0.0" targetFramework="net45" />
   <package id="OpenHardwareMonitor" version="0.7.1" targetFramework="net45" />


### PR DESCRIPTION
Add Selected Pool(s) would previously allow anything that was a non-empty
string. This has been changed to base58check with Vertcoin's version bytes.